### PR TITLE
Updates hyperlinks to point to opencardev repo.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
 					<ul>
 					  <li><a target="_blank" href="https://www.reddit.com/r/crankshaft/">Subreddit</a></li>
 					  <li><a target="_blank" href="https://photos.app.goo.gl/81hQ6wTuLFNGmRHh2">Pictures</a></li>
-					  <li><a target="_blank" href="https://github.com/htruong/crankshaft/wiki">Wiki</a></li>
+					  <li><a target="_blank" href="https://github.com/opencardev/crankshaft/wiki">Wiki</a></li>
 					  <li><a target="_blank" href="https://patreon.com/crankshaft">Patreon</a></li>
 					  <!--<li><a target="_blank" href="http://www.tnhh.net/topic/crankshaft/">Blog</a></li>-->
 					</ul>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ title: Crankshaft = Raspberry Pi 💖 Android Auto
 				<p>Some (outdated) demos: <a href="https://photos.google.com/share/AF1QipP3hcflM2fty5ziB_yuFl1_4hJL2r1LlWdvdUgCROp0DqsgiTJgm5lJUoDY6aO5aA/photo/AF1QipP1fOBkbERhqqrxH7asmEPUr9bvUilW8-RpQnbI?key=SmkydlU1eVFEb20xOHFJX0ZZUk9KY3NGR2dlcVhB" target="_blank">In-car</a>, <a href="https://youtu.be/tFEpfuDBDjM" target="_blank">Features</a>.</p>
 				<p class="subtitle">Latest version: NG Alpha-4 - Released 2019/03/03.<br /><a href="http://www.somsubhra.com/github-release-stats/?username=opencardev&repository=crankshaft" target="_blank">Download stats</a> <!--<br /><a href="https://www.reddit.com/r/crankshaft/comments/8agvly/_/" target="_blank">Read the release announcement</a>--></p>
 				<div class="button">
-					<a href="https://github.com/opencardev/crankshaft/wiki/Getting-started-with-Crankshaft" target="_blank">Get started</a> <a href="https://github.com/opencardev/crankshaft/releases" target="_blank">Download Crankshaft</a> 
+					<a href="https://github.com/opencardev/crankshaft/wiki/Getting-started-with-Crankshaft" target="_blank">Get started</a> <a href="https://github.com/opencardev/crankshaft/releases" target="_blank">Download Crankshaft</a>
 				</div>
 			</div>
 		</div>
@@ -35,13 +35,13 @@ title: Crankshaft = Raspberry Pi 💖 Android Auto
 		<li>
 			<div class="image">{% include icons/site.html icon="population" %}</div>
 			<h3 class="editable">Free Software</h3>
-			<p class="editable">Crankshaft <a href="https://github.com/opencardev/crankshaft/blob/master/SOCIAL-CONTRACT.md" target="_blank">respects your freedom</a> as guaranteed by the GPLv3, powered by <a href="https://github.com/f1xpl/openauto" target="_blank">OpenAuto</a>. <a href="https://github.com/htruong/crankshaft" href="_blank">Sourcecode</a>.</p>
+			<p class="editable">Crankshaft <a href="https://github.com/opencardev/crankshaft/blob/master/SOCIAL-CONTRACT.md" target="_blank">respects your freedom</a> as guaranteed by the GPLv3, powered by <a href="https://github.com/f1xpl/openauto" target="_blank">OpenAuto</a>. <a href="https://github.com/opencardev/crankshaft" href="_blank">Sourcecode</a>.</p>
 		</li>
-		
+
 		<li>
 			<div class="image">{% include icons/site.html icon="economy" %}</div>
 			<h3 class="editable">Powerful</h3>
-			<p class="editable">Crankshaft makes it easy for you to <a href="https://github.com/htruong/crankshaft/wiki/Customizing-Crankshaft" target="_blank">customize</a> and <a href="https://github.com/htruong/crankshaft/wiki/Crankshaft-dev-mode" target="_blank">develop</a> on it.</p>
+			<p class="editable">Crankshaft makes it easy for you to <a href="https://github.com/opencardev/crankshaft/wiki/Customizing-Crankshaft" target="_blank">customize</a> and <a href="https://github.com/opencardev/crankshaft/wiki/Crankshaft-dev-mode" target="_blank">develop</a> on it.</p>
 		</li>
 	</ul>
 </div>
@@ -57,9 +57,9 @@ title: Crankshaft = Raspberry Pi 💖 Android Auto
 			<p class="editable">It is alpha-level software, so no. It's not an official or even related to or certified by Google or Android. It's totally a hobby. But we hope you give it a try and have fun with it when it's safe to do so.</p>
 			<p class="editable">If you're a developer who is able to compile software on Linux, you can try to follow <a href="https://github.com/f1xpl/openauto" target="_blank">OpenAuto</a>'s instructions even when Crankshaft doesn't work on your custom hardware.</p>
 			<p>
-				<a href="https://github.com/htruong/crankshaft/issues/2" target="_blank">Phones/Hardware compatibility list</a><br />
+				<a href="https://github.com/opencardev/crankshaft/issues/2" target="_blank">Phones/Hardware compatibility list</a><br />
 			</p>
-			
+
 		</div>
 	</div>
 </div>
@@ -69,7 +69,7 @@ title: Crankshaft = Raspberry Pi 💖 Android Auto
 		<h2 class="editable">Join us</h2>
 		<p class="editable" style="text-align: center;">Bugs? Ideas? Want to help?<br />
 			<a href="https://www.reddit.com/r/crankshaft/">Join the subreddit!</a><br />
-			<a href="https://github.com/htruong/crankshaft/issues">Report problems</a> (<a href="https://github.com/htruong/crankshaft#want-to-report-a-problem" target="_blank">How to debug</a>) <br />
+			<a href="https://github.com/opencardev/crankshaft/issues">Report problems</a> (<a href="https://github.com/opencardev/crankshaft#want-to-report-a-problem" target="_blank">How to debug</a>) <br />
 			<!--<a href="https://gitter.im/openauto_androidauto/Lobby">Join the conversation at gitter</a><br />
 	   Or <a href="mailto:webreg@tnhh.net">send the maintainer an email</a>--></p>
 	</div>
@@ -80,7 +80,7 @@ title: Crankshaft = Raspberry Pi 💖 Android Auto
 	<div class="donate">
 		If you enjoy OpenAuto, please consider <a href="https://bluewavestudio.io/index.php/bluewave-shop" target="_blank">shopping at BlueWave Studio</a>.<br />
 		<br />
-		Check out a similar kickass Free software project: <a href="http://headunit.viktorgino.me/" target="_blank">Headunit Desktop - comprehensive car PC software</a>.</p> 
+		Check out a similar kickass Free software project: <a href="http://headunit.viktorgino.me/" target="_blank">Headunit Desktop - comprehensive car PC software</a>.</p>
 	</div>
 </div>
 <!--


### PR DESCRIPTION
It appears that htruong/crankshaft was renamed to opencardev/crankshaft. While github’s redirects are working properly, I was a bit confused by the links on the website. This fixes the links to point to the new and correct repo URL: https://github.com/opencardev/crankshaft